### PR TITLE
[Change] Java 7 (Potentially down to Java 5) Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ plugins {
 group "meteordevelopment"
 version "0.2.2"
 
-sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_7
 
 java {
-    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_7
 
     withSourcesJar()
     withJavadocJar()

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.nio.file.Files
+
 plugins {
     id "java"
     id "maven-publish"
@@ -6,10 +8,10 @@ plugins {
 group "meteordevelopment"
 version "0.2.2"
 
-sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
 java {
-    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
     withSourcesJar()
     withJavadocJar()
@@ -28,6 +30,43 @@ dependencies {
 
 compileJava {
     options.encoding = "UTF-8"
+
+    // Note: This will fail if the JVM is above Java 8 (Fork RetroLambda to fix)
+    doLast {
+        var retrolambaJar = new URL("https://oss.sonatype.org/content/groups/public/net/orfjackal/retrolambda/retrolambda/2.5.7/retrolambda-2.5.7.jar")
+        var retrolambdaFile = new File("${rootProject.buildDir}/retrolambda/retrolambda.jar")
+        if (!retrolambdaFile.exists()) {
+            retrolambdaFile.getParentFile().mkdirs()
+            try (InputStream is = retrolambaJar.openStream()) {
+                Files.copy(is, retrolambdaFile.toPath())
+            }
+        }
+        var classpath = project.sourceSets.main.runtimeClasspath
+        var classpathString = classpath.files.collect { it.absolutePath }.join(File.pathSeparator)
+        var javahome = System.getProperty("java.home")
+        var javaexe = javahome + File.separator + "bin" + File.separator + "java"
+        if (System.getProperty("os.name").toLowerCase().contains("win") && !System.getProperty("os.name").toLowerCase().contains("darwin")) {
+            javaexe += ".exe"
+        }
+        var processBuilder = new ProcessBuilder(
+                javaexe,
+                "-Dretrolambda.inputDir=${compileJava.destinationDir.toString().replace("\\", "\\\\").replace(" ", "\\ ")}",
+                "-Dretrolambda.classpath=${classpathString.replace("\\", "\\\\").replace(" ", "\\ ")}",
+                "-Dretrolambda.defaultMethods=true",
+                "-Dretrolambda.bytecodeVersion=51",
+                "-javaagent:${retrolambdaFile.absolutePath.toString().replace("\\", "\\\\").replace(" ", "\\ ")}",
+                "-jar",
+                retrolambdaFile.absolutePath.toString().replace("\\", "\\\\").replace(" ", "\\ "),
+        )
+        var outputLog = new File("${rootProject.buildDir}/retrolambda/${project.path.replace(":", "_")}output.log")
+        processBuilder.redirectOutput(outputLog)
+        processBuilder.redirectError(outputLog)
+        var process = processBuilder.start()
+        process.waitFor()
+        if (process.exitValue() != 0) {
+            throw new GradleException("RetroLambda failed with exit code " + process.exitValue())
+        }
+    }
 }
 
 compileTestJava {

--- a/src/main/java/meteordevelopment/starscript/Section.java
+++ b/src/main/java/meteordevelopment/starscript/Section.java
@@ -1,7 +1,14 @@
 package meteordevelopment.starscript;
 
+import java.util.function.Supplier;
+
 public class Section {
-    private static final ThreadLocal<StringBuilder> SB = ThreadLocal.withInitial(StringBuilder::new);
+    private static final ThreadLocal<StringBuilder> SB =
+            new ThreadLocal<StringBuilder>() {
+                @Override protected StringBuilder initialValue() {
+                    return new StringBuilder();
+                }
+            };
 
     public final int index;
     public final String text;

--- a/src/main/java/meteordevelopment/starscript/Section.java
+++ b/src/main/java/meteordevelopment/starscript/Section.java
@@ -1,7 +1,5 @@
 package meteordevelopment.starscript;
 
-import java.util.function.Supplier;
-
 public class Section {
     // DNT: Java 7 Support needs this
     @SuppressWarnings("AnonymousHasLambdaAlternative")

--- a/src/main/java/meteordevelopment/starscript/Section.java
+++ b/src/main/java/meteordevelopment/starscript/Section.java
@@ -3,6 +3,8 @@ package meteordevelopment.starscript;
 import java.util.function.Supplier;
 
 public class Section {
+    // DNT: Java 7 Support needs this
+    @SuppressWarnings("AnonymousHasLambdaAlternative")
     private static final ThreadLocal<StringBuilder> SB =
             new ThreadLocal<StringBuilder>() {
                 @Override protected StringBuilder initialValue() {

--- a/src/main/java/meteordevelopment/starscript/StandardLib.java
+++ b/src/main/java/meteordevelopment/starscript/StandardLib.java
@@ -1,12 +1,10 @@
 package meteordevelopment.starscript;
 
-import meteordevelopment.starscript.utils.SFunction;
 import meteordevelopment.starscript.value.Value;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Random;
-import java.util.concurrent.Callable;
 
 /** Standard library with some default functions and variables. */
 public class StandardLib {
@@ -19,94 +17,24 @@ public class StandardLib {
     public static void init(Starscript ss) throws Exception {
         // Variables
         ss.set("PI", Math.PI);
-        ss.set("time", new Callable<Value>() {
-            @Override
-            public Value call() {
-                return Value.string(timeFormat.format(new Date()));
-            }
-        });
-        ss.set("date", new Callable<Value>() {
-            @Override
-            public Value call() {
-                return Value.string(dateFormat.format(new Date()));
-            }
-        });
+        ss.set("time", () -> Value.string(timeFormat.format(new Date())));
+        ss.set("date", () -> Value.string(dateFormat.format(new Date())));
 
         // Numbers
-        ss.set("round", new SFunction() {
-            @Override
-            public Value run(Starscript ss12, int argCount11) {
-                return round(ss12, argCount11);
-            }
-        });
-        ss.set("roundToString", new SFunction() {
-            @Override
-            public Value run(Starscript ss11, int argCount10) {
-                return roundToString(ss11, argCount10);
-            }
-        });
-        ss.set("floor", new SFunction() {
-            @Override
-            public Value run(Starscript ss10, int argCount9) {
-                return floor(ss10, argCount9);
-            }
-        });
-        ss.set("ceil", new SFunction() {
-            @Override
-            public Value run(Starscript ss9, int argCount8) {
-                return ceil(ss9, argCount8);
-            }
-        });
-        ss.set("abs", new SFunction() {
-            @Override
-            public Value run(Starscript ss8, int argCount7) {
-                return abs(ss8, argCount7);
-            }
-        });
-        ss.set("random", new SFunction() {
-            @Override
-            public Value run(Starscript ss7, int argCount6) {
-                return random(ss7, argCount6);
-            }
-        });
+        ss.set("round", StandardLib::round);
+        ss.set("roundToString", StandardLib::roundToString);
+        ss.set("floor", StandardLib::floor);
+        ss.set("ceil", StandardLib::ceil);
+        ss.set("abs", StandardLib::abs);
+        ss.set("random", StandardLib::random);
 
         // Strings
-        ss.set("string", new SFunction() {
-            @Override
-            public Value run(Starscript ss6, int argCount5) {
-                return string(ss6, argCount5);
-            }
-        });
-        ss.set("toUpper", new SFunction() {
-            @Override
-            public Value run(Starscript ss5, int argCount4) {
-                return toUpper(ss5, argCount4);
-            }
-        });
-        ss.set("toLower", new SFunction() {
-            @Override
-            public Value run(Starscript ss4, int argCount3) {
-                return toLower(ss4, argCount3);
-            }
-        });
-        ss.set("contains", new SFunction() {
-            @Override
-            public Value run(Starscript ss3, int argCount2) {
-                return contains(ss3, argCount2);
-            }
-        });
-        ss.set("replace", new SFunction() {
-            @Override
-            public Value run(Starscript ss2, int argCount1) {
-                return replace(ss2, argCount1);
-            }
-        });
-        ss.set("pad", new SFunction() {
-            @Override
-            public Value run(Starscript ss1, int argCount) {
-                return pad(ss1, argCount);
-            }
-        });
+        ss.set("string", StandardLib::string);
+        ss.set("toUpper", StandardLib::toUpper);
+        ss.set("toLower", StandardLib::toLower);
+        ss.set("contains", StandardLib::contains);
+        ss.set("replace", StandardLib::replace);
+        ss.set("pad", StandardLib::pad);
     }
 
     // Numbers

--- a/src/main/java/meteordevelopment/starscript/StandardLib.java
+++ b/src/main/java/meteordevelopment/starscript/StandardLib.java
@@ -1,10 +1,12 @@
 package meteordevelopment.starscript;
 
+import meteordevelopment.starscript.utils.SFunction;
 import meteordevelopment.starscript.value.Value;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Random;
+import java.util.concurrent.Callable;
 
 /** Standard library with some default functions and variables. */
 public class StandardLib {
@@ -14,27 +16,97 @@ public class StandardLib {
     public static final SimpleDateFormat dateFormat = new SimpleDateFormat("dd. MM. yyyy");
 
     /** Adds the functions and variables to the provided {@link Starscript} instance. */
-    public static void init(Starscript ss) {
+    public static void init(Starscript ss) throws Exception {
         // Variables
         ss.set("PI", Math.PI);
-        ss.set("time", () -> Value.string(timeFormat.format(new Date())));
-        ss.set("date", () -> Value.string(dateFormat.format(new Date())));
+        ss.set("time", new Callable<Value>() {
+            @Override
+            public Value call() {
+                return Value.string(timeFormat.format(new Date()));
+            }
+        });
+        ss.set("date", new Callable<Value>() {
+            @Override
+            public Value call() {
+                return Value.string(dateFormat.format(new Date()));
+            }
+        });
 
         // Numbers
-        ss.set("round", StandardLib::round);
-        ss.set("roundToString", StandardLib::roundToString);
-        ss.set("floor", StandardLib::floor);
-        ss.set("ceil", StandardLib::ceil);
-        ss.set("abs", StandardLib::abs);
-        ss.set("random", StandardLib::random);
+        ss.set("round", new SFunction() {
+            @Override
+            public Value run(Starscript ss12, int argCount11) {
+                return round(ss12, argCount11);
+            }
+        });
+        ss.set("roundToString", new SFunction() {
+            @Override
+            public Value run(Starscript ss11, int argCount10) {
+                return roundToString(ss11, argCount10);
+            }
+        });
+        ss.set("floor", new SFunction() {
+            @Override
+            public Value run(Starscript ss10, int argCount9) {
+                return floor(ss10, argCount9);
+            }
+        });
+        ss.set("ceil", new SFunction() {
+            @Override
+            public Value run(Starscript ss9, int argCount8) {
+                return ceil(ss9, argCount8);
+            }
+        });
+        ss.set("abs", new SFunction() {
+            @Override
+            public Value run(Starscript ss8, int argCount7) {
+                return abs(ss8, argCount7);
+            }
+        });
+        ss.set("random", new SFunction() {
+            @Override
+            public Value run(Starscript ss7, int argCount6) {
+                return random(ss7, argCount6);
+            }
+        });
 
         // Strings
-        ss.set("string", StandardLib::string);
-        ss.set("toUpper", StandardLib::toUpper);
-        ss.set("toLower", StandardLib::toLower);
-        ss.set("contains", StandardLib::contains);
-        ss.set("replace", StandardLib::replace);
-        ss.set("pad", StandardLib::pad);
+        ss.set("string", new SFunction() {
+            @Override
+            public Value run(Starscript ss6, int argCount5) {
+                return string(ss6, argCount5);
+            }
+        });
+        ss.set("toUpper", new SFunction() {
+            @Override
+            public Value run(Starscript ss5, int argCount4) {
+                return toUpper(ss5, argCount4);
+            }
+        });
+        ss.set("toLower", new SFunction() {
+            @Override
+            public Value run(Starscript ss4, int argCount3) {
+                return toLower(ss4, argCount3);
+            }
+        });
+        ss.set("contains", new SFunction() {
+            @Override
+            public Value run(Starscript ss3, int argCount2) {
+                return contains(ss3, argCount2);
+            }
+        });
+        ss.set("replace", new SFunction() {
+            @Override
+            public Value run(Starscript ss2, int argCount1) {
+                return replace(ss2, argCount1);
+            }
+        });
+        ss.set("pad", new SFunction() {
+            @Override
+            public Value run(Starscript ss1, int argCount) {
+                return pad(ss1, argCount);
+            }
+        });
     }
 
     // Numbers

--- a/src/main/java/meteordevelopment/starscript/compiler/Compiler.java
+++ b/src/main/java/meteordevelopment/starscript/compiler/Compiler.java
@@ -18,7 +18,7 @@ public class Compiler implements Expr.Visitor {
     private Compiler() {}
 
     /** Produces compiled {@link Script} from {@link Parser.Result} that can be run inside {@link meteordevelopment.starscript.Starscript}. */
-    public static Script compile(Parser.Result result) {
+    public static Script compile(Parser.Result result) throws Exception {
         Compiler compiler = new Compiler();
 
         for (Expr expr : result.exprs) compiler.compile(expr);
@@ -50,7 +50,7 @@ public class Compiler implements Expr.Visitor {
     }
 
     @Override
-    public void visitBlock(Expr.Block expr) {
+    public void visitBlock(Expr.Block expr) throws Exception {
         blockDepth++;
 
         if (expr.getExpr() instanceof Expr.String) constantAppend = true;
@@ -72,12 +72,12 @@ public class Compiler implements Expr.Visitor {
     }
 
     @Override
-    public void visitGroup(Expr.Group expr) {
+    public void visitGroup(Expr.Group expr) throws Exception {
         compile(expr.getExpr());
     }
 
     @Override
-    public void visitBinary(Expr.Binary expr) {
+    public void visitBinary(Expr.Binary expr) throws Exception {
         compile(expr.getLeft());
 
         if (expr.op == Token.Plus && (expr.getRight() instanceof Expr.String || expr.getRight() instanceof Expr.Number)) {
@@ -104,7 +104,7 @@ public class Compiler implements Expr.Visitor {
     }
 
     @Override
-    public void visitUnary(Expr.Unary expr) {
+    public void visitUnary(Expr.Unary expr) throws Exception {
         compile(expr.getRight());
 
         if (expr.op == Token.Bang) script.write(Instruction.Not);
@@ -117,7 +117,7 @@ public class Compiler implements Expr.Visitor {
     }
 
     @Override
-    public void visitGet(Expr.Get expr) {
+    public void visitGet(Expr.Get expr) throws Exception {
         boolean prevGetAppend = getAppend;
         getAppend = false;
 
@@ -134,7 +134,7 @@ public class Compiler implements Expr.Visitor {
     }
 
     @Override
-    public void visitCall(Expr.Call expr) {
+    public void visitCall(Expr.Call expr) throws Exception {
         boolean prevCallAppend = callAppend;
         compile(expr.getCallee());
 
@@ -146,7 +146,7 @@ public class Compiler implements Expr.Visitor {
     }
 
     @Override
-    public void visitLogical(Expr.Logical expr) {
+    public void visitLogical(Expr.Logical expr) throws Exception {
         compile(expr.getLeft());
         int endJump = script.writeJump(expr.op == Token.And ? Instruction.JumpIfFalse : Instruction.JumpIfTrue);
 
@@ -157,7 +157,7 @@ public class Compiler implements Expr.Visitor {
     }
 
     @Override
-    public void visitConditional(Expr.Conditional expr) {
+    public void visitConditional(Expr.Conditional expr) throws Exception {
         compile(expr.getCondition());
         int falseJump = script.writeJump(Instruction.JumpIfFalse);
 
@@ -173,14 +173,14 @@ public class Compiler implements Expr.Visitor {
     }
 
     @Override
-    public void visitSection(Expr.Section expr) {
+    public void visitSection(Expr.Section expr) throws Exception {
         script.write(Instruction.Section, expr.index);
         compile(expr.getExpr());
     }
 
     // Helpers
 
-    private void compile(Expr expr) {
+    private void compile(Expr expr) throws Exception {
         if (expr != null) expr.accept(this);
     }
 }

--- a/src/main/java/meteordevelopment/starscript/compiler/Expr.java
+++ b/src/main/java/meteordevelopment/starscript/compiler/Expr.java
@@ -7,20 +7,20 @@ public abstract class Expr {
     private static final Expr[] EMPTY_CHILDREN = new Expr[0];
 
     public interface Visitor {
-        void visitNull(Null expr);
-        void visitString(String expr);
-        void visitNumber(Number expr);
-        void visitBool(Bool expr);
-        void visitBlock(Block expr);
-        void visitGroup(Group expr);
-        void visitBinary(Binary expr);
-        void visitUnary(Unary expr);
-        void visitVariable(Variable expr);
-        void visitGet(Get expr);
-        void visitCall(Call expr);
-        void visitLogical(Logical expr);
-        void visitConditional(Conditional expr);
-        void visitSection(Section expr);
+        void visitNull(Null expr) throws Exception;
+        void visitString(String expr) throws Exception;
+        void visitNumber(Number expr) throws Exception;
+        void visitBool(Bool expr) throws Exception;
+        void visitBlock(Block expr) throws Exception;
+        void visitGroup(Group expr) throws Exception;
+        void visitBinary(Binary expr) throws Exception;
+        void visitUnary(Unary expr) throws Exception;
+        void visitVariable(Variable expr) throws Exception;
+        void visitGet(Get expr) throws Exception;
+        void visitCall(Call expr) throws Exception;
+        void visitLogical(Logical expr) throws Exception;
+        void visitConditional(Conditional expr) throws Exception;
+        void visitSection(Section expr) throws Exception;
     }
 
     public final int start, end;
@@ -42,7 +42,7 @@ public abstract class Expr {
         this(start, end, EMPTY_CHILDREN);
     }
 
-    public abstract void accept(Visitor visitor);
+    public abstract void accept(Visitor visitor) throws Exception;
 
     public java.lang.String getSource(java.lang.String source) {
         return source.substring(start, end);
@@ -70,7 +70,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitNull(this);
         }
     }
@@ -85,7 +85,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitString(this);
         }
     }
@@ -100,7 +100,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitNumber(this);
         }
     }
@@ -115,7 +115,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitBool(this);
         }
     }
@@ -126,7 +126,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitBlock(this);
         }
 
@@ -141,7 +141,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitGroup(this);
         }
 
@@ -160,7 +160,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitBinary(this);
         }
 
@@ -183,7 +183,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitUnary(this);
         }
 
@@ -202,7 +202,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitVariable(this);
         }
     }
@@ -217,7 +217,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitGet(this);
         }
 
@@ -232,7 +232,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitCall(this);
         }
 
@@ -268,7 +268,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitLogical(this);
         }
 
@@ -287,7 +287,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitConditional(this);
         }
 
@@ -314,7 +314,7 @@ public abstract class Expr {
         }
 
         @Override
-        public void accept(Visitor visitor) {
+        public void accept(Visitor visitor) throws Exception {
             visitor.visitSection(this);
         }
 

--- a/src/main/java/meteordevelopment/starscript/compiler/Parser.java
+++ b/src/main/java/meteordevelopment/starscript/compiler/Parser.java
@@ -355,7 +355,7 @@ public class Parser {
             return errors.size() > 0;
         }
 
-        public void accept(Expr.Visitor visitor) {
+        public void accept(Expr.Visitor visitor) throws Exception {
             for (Expr expr : exprs) expr.accept(visitor);
         }
     }

--- a/src/main/java/meteordevelopment/starscript/utils/AbstractExprVisitor.java
+++ b/src/main/java/meteordevelopment/starscript/utils/AbstractExprVisitor.java
@@ -4,72 +4,72 @@ import meteordevelopment.starscript.compiler.Expr;
 
 public abstract class AbstractExprVisitor implements Expr.Visitor {
     @Override
-    public void visitNull(Expr.Null expr) {
+    public void visitNull(Expr.Null expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitString(Expr.String expr) {
+    public void visitString(Expr.String expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitNumber(Expr.Number expr) {
+    public void visitNumber(Expr.Number expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitBool(Expr.Bool expr) {
+    public void visitBool(Expr.Bool expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitBlock(Expr.Block expr) {
+    public void visitBlock(Expr.Block expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitGroup(Expr.Group expr) {
+    public void visitGroup(Expr.Group expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitBinary(Expr.Binary expr) {
+    public void visitBinary(Expr.Binary expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitUnary(Expr.Unary expr) {
+    public void visitUnary(Expr.Unary expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitVariable(Expr.Variable expr) {
+    public void visitVariable(Expr.Variable expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitGet(Expr.Get expr) {
+    public void visitGet(Expr.Get expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitCall(Expr.Call expr) {
+    public void visitCall(Expr.Call expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitLogical(Expr.Logical expr) {
+    public void visitLogical(Expr.Logical expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitConditional(Expr.Conditional expr) {
+    public void visitConditional(Expr.Conditional expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 
     @Override
-    public void visitSection(Expr.Section expr) {
+    public void visitSection(Expr.Section expr) throws Exception {
         for (Expr child : expr.children) child.accept(this);
     }
 }

--- a/src/main/java/meteordevelopment/starscript/utils/VariableReplacementTransformer.java
+++ b/src/main/java/meteordevelopment/starscript/utils/VariableReplacementTransformer.java
@@ -4,7 +4,7 @@ import meteordevelopment.starscript.compiler.Expr;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.concurrent.Callable;
 
 /**
  * Replaces usages of variables or get expressions with a different expression. <strong>Doesn't support functions.</strong><br><br>
@@ -14,29 +14,29 @@ import java.util.function.Supplier;
  * addReplacer("player.name", () -> "foo.bar");
  */
 public class VariableReplacementTransformer extends AbstractExprVisitor {
-    private final Map<String, Supplier<String>> replacers = new HashMap<>();
+    private final Map<String, Callable<String>> replacers = new HashMap<>();
     private final StringBuilder sb = new StringBuilder();
 
-    public void addReplacer(String name, Supplier<String> supplier) {
+    public void addReplacer(String name, Callable<String> supplier) {
         replacers.put(name, supplier);
     }
 
     @Override
-    public void visitVariable(Expr.Variable expr) {
+    public void visitVariable(Expr.Variable expr) throws Exception {
         tryReplace(expr, expr.name);
     }
 
     @Override
-    public void visitGet(Expr.Get expr) {
+    public void visitGet(Expr.Get expr) throws Exception {
         String name = getFullName(expr);
         if (name != null) tryReplace(expr, name);
     }
 
-    private void tryReplace(Expr expr, String name) {
-        Supplier<String> replacer = replacers.get(name);
+    private void tryReplace(Expr expr, String name) throws Exception {
+        Callable<String> replacer = replacers.get(name);
         if (replacer == null) return;
 
-        Expr replacement = createReplacement(replacer.get());
+        Expr replacement = createReplacement(replacer.call());
         expr.replace(replacement);
     }
 

--- a/src/main/java/meteordevelopment/starscript/value/Value.java
+++ b/src/main/java/meteordevelopment/starscript/value/Value.java
@@ -2,7 +2,7 @@ package meteordevelopment.starscript.value;
 
 import meteordevelopment.starscript.utils.SFunction;
 
-import java.util.function.Supplier;
+import java.util.concurrent.Callable;
 
 /** Class that holds any starscript value. */
 public class Value {
@@ -125,8 +125,12 @@ public class Value {
             case String:   return getString();
             case Function: return "<function>";
             case Map: {
-                Supplier<Value> s = getMap().getRaw("_toString");
-                return s == null ? "<map>" : s.get().toString();
+                Callable<Value> s = getMap().getRaw("_toString");
+                try {
+                    return s == null ? "<map>" : s.call().toString();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
             }
             default:       return "";
         }

--- a/src/main/java/meteordevelopment/starscript/value/ValueMap.java
+++ b/src/main/java/meteordevelopment/starscript/value/ValueMap.java
@@ -5,11 +5,11 @@ import meteordevelopment.starscript.utils.SFunction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.concurrent.Callable;
 
-/** Simpler wrapper around a map that goes from {@link String} to {@link Supplier} for {@link Value}. */
+/** Simpler wrapper around a map that goes from {@link String} to {@link Callable} for {@link Value}. */
 public class ValueMap {
-    private final Map<String, Supplier<Value>> values = new HashMap<>();
+    private final Map<String, Callable<Value>> values = new HashMap<>();
 
     /**
      * Sets a variable supplier for the provided name. <br><br>
@@ -17,7 +17,7 @@ public class ValueMap {
      * <strong>Dot Notation:</strong><br>
      * If the name contains a dot it is automatically split into separate value maps. For example the name 'player.name' will not put a single string value with the name 'player.name' into this value map but another value map with the name 'player' and then inside that a string value with the name 'name'. If there already is a value named 'player' and it is a map, it just adds to that existing map, otherwise it replaces the value.
      */
-    public ValueMap set(String name, Supplier<Value> supplier) {
+    public ValueMap set(String name, Callable<Value> supplier) throws Exception {
         int dotI = name.indexOf('.');
 
         if (dotI >= 0) {
@@ -26,20 +26,30 @@ public class ValueMap {
             String name2 = name.substring(dotI + 1);
 
             // Get the map
-            ValueMap map;
-            Supplier<Value> valueSupplier = values.get(name1);
+            final ValueMap map;
+            Callable<Value> valueSupplier = values.get(name1);
 
             if (valueSupplier == null) {
                 map = new ValueMap();
-                values.put(name1, () -> Value.map(map));
+                values.put(name1, new Callable<Value>() {
+                    @Override
+                    public Value call() {
+                        return Value.map(map);
+                    }
+                });
             }
             else {
-                Value value = valueSupplier.get();
+                Value value = valueSupplier.call();
 
                 if (value.isMap()) map = value.getMap();
                 else {
                     map = new ValueMap();
-                    values.put(name1, () -> Value.map(map));
+                    values.put(name1, new Callable<Value>() {
+                        @Override
+                        public Value call() {
+                            return Value.map(map);
+                        }
+                    });
                 }
             }
 
@@ -51,34 +61,39 @@ public class ValueMap {
         return this;
     }
 
-    /** Sets a variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Supplier)} for dot notation. */
-    public ValueMap set(String name, Value value) {
-        set(name, () -> value);
+    /** Sets a variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Callable)} for dot notation. */
+    public ValueMap set(String name, final Value value) throws Exception {
+        set(name, new Callable<Value>() {
+            @Override
+            public Value call() {
+                return value;
+            }
+        });
         return this;
     }
 
-    /** Sets a boolean variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Supplier)} for dot notation. */
-    public ValueMap set(String name, boolean bool) {
+    /** Sets a boolean variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Callable)} for dot notation. */
+    public ValueMap set(String name, boolean bool) throws Exception {
         return set(name, Value.bool(bool));
     }
 
-    /** Sets a number variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Supplier)} for dot notation. */
-    public ValueMap set(String name, double number) {
+    /** Sets a number variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Callable)} for dot notation. */
+    public ValueMap set(String name, double number) throws Exception {
         return set(name, Value.number(number));
     }
 
-    /** Sets a string variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Supplier)} for dot notation. */
-    public ValueMap set(String name, String string) {
+    /** Sets a string variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Callable)} for dot notation. */
+    public ValueMap set(String name, String string) throws Exception {
         return set(name, Value.string(string));
     }
 
-    /** Sets a function variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Supplier)} for dot notation. */
-    public ValueMap set(String name, SFunction function) {
+    /** Sets a function variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Callable)} for dot notation. */
+    public ValueMap set(String name, SFunction function) throws Exception {
         return set(name, Value.function(function));
     }
 
-    /** Sets a map variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Supplier)} for dot notation. */
-    public ValueMap set(String name, ValueMap map) {
+    /** Sets a map variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Callable)} for dot notation. */
+    public ValueMap set(String name, ValueMap map) throws Exception {
         return set(name, Value.map(map));
     }
 
@@ -86,9 +101,9 @@ public class ValueMap {
      * Gets the variable supplier for the provided name. <br><br>
      *
      * <strong>Dot Notation:</strong><br>
-     * If the name is for example 'player.name' then it gets a value with the name 'player' from this map and calls .get() with 'name' on the second map. If 'player' is not a map then returns null. See {@link #set(String, Supplier)}.
+     * If the name is for example 'player.name' then it gets a value with the name 'player' from this map and calls .get() with 'name' on the second map. If 'player' is not a map then returns null. See {@link #set(String, Callable)}.
      */
-    public Supplier<Value> get(String name) {
+    public Callable<Value> get(String name) throws Exception {
         int dotI = name.indexOf('.');
 
         if (dotI >= 0) {
@@ -97,11 +112,11 @@ public class ValueMap {
             String name2 = name.substring(dotI + 1);
 
             // Get child value
-            Supplier<Value> valueSupplier = values.get(name1);
+            Callable<Value> valueSupplier = values.get(name1);
             if (valueSupplier == null) return null;
 
             // Make sure the child value is a map
-            Value value = valueSupplier.get();
+            Value value = valueSupplier.call();
             if (!value.isMap()) return null;
 
             // Get value from the child map
@@ -112,7 +127,7 @@ public class ValueMap {
     }
 
     /** Gets the variable supplier for the provided name. */
-    public Supplier<Value> getRaw(String name) {
+    public Callable<Value> getRaw(String name) {
         return values.get(name);
     }
 
@@ -130,7 +145,7 @@ public class ValueMap {
      * Removes a single value with the specified name from this map. <br><br>
      *
      * <strong>Dot Notation:</strong><br>
-     * If the name is for example 'player.name' then it removes a value with the name 'player' from this map. See {@link #set(String, Supplier)}.
+     * If the name is for example 'player.name' then it removes a value with the name 'player' from this map. See {@link #set(String, Callable)}.
      */
     public void remove(String name) {
         int dotI = name.indexOf('.');

--- a/src/main/java/meteordevelopment/starscript/value/ValueMap.java
+++ b/src/main/java/meteordevelopment/starscript/value/ValueMap.java
@@ -31,12 +31,7 @@ public class ValueMap {
 
             if (valueSupplier == null) {
                 map = new ValueMap();
-                values.put(name1, new Callable<Value>() {
-                    @Override
-                    public Value call() {
-                        return Value.map(map);
-                    }
-                });
+                values.put(name1, () -> Value.map(map));
             }
             else {
                 Value value = valueSupplier.call();
@@ -44,12 +39,7 @@ public class ValueMap {
                 if (value.isMap()) map = value.getMap();
                 else {
                     map = new ValueMap();
-                    values.put(name1, new Callable<Value>() {
-                        @Override
-                        public Value call() {
-                            return Value.map(map);
-                        }
-                    });
+                    values.put(name1, () -> Value.map(map));
                 }
             }
 
@@ -63,12 +53,7 @@ public class ValueMap {
 
     /** Sets a variable supplier that always returns the same value for the provided name. <br><br> See {@link #set(String, Callable)} for dot notation. */
     public ValueMap set(String name, final Value value) throws Exception {
-        set(name, new Callable<Value>() {
-            @Override
-            public Value call() {
-                return value;
-            }
-        });
+        set(name, () -> value);
         return this;
     }
 

--- a/src/test/java/meteordevelopment/starscript/Benchmark.java
+++ b/src/test/java/meteordevelopment/starscript/Benchmark.java
@@ -52,7 +52,7 @@ public class Benchmark {
     public Starscript ss;
 
     @Setup
-    public void setup() {
+    public void setup() throws Exception {
         sb = new StringBuilder();
 
         // Format
@@ -79,7 +79,7 @@ public class Benchmark {
     }
 
     @org.openjdk.jmh.annotations.Benchmark
-    public void starscript(Blackhole bh) {
+    public void starscript(Blackhole bh) throws Exception {
         bh.consume(ss.run(script, sb).toString());
     }
 }

--- a/src/test/java/meteordevelopment/starscript/Main.java
+++ b/src/test/java/meteordevelopment/starscript/Main.java
@@ -3,13 +3,14 @@ package meteordevelopment.starscript;
 import meteordevelopment.starscript.compiler.Compiler;
 import meteordevelopment.starscript.compiler.Parser;
 import meteordevelopment.starscript.utils.Error;
+import meteordevelopment.starscript.utils.SFunction;
 import meteordevelopment.starscript.value.Value;
 import meteordevelopment.starscript.value.ValueMap;
 
 public class Main {
     private static final boolean USE_DOT_NOTATION = true;
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         String source = "Name: {player.name}     Age: {player.age()}";
 
         Parser.Result result = Parser.parse(source);
@@ -28,12 +29,22 @@ public class Main {
 
         if (USE_DOT_NOTATION) {
             ss.set("player.name", "MineGame159");
-            ss.set("player.age", (ss1, agrCount) -> Value.number(5));
+            ss.set("player.age", new SFunction() {
+                @Override
+                public Value run(Starscript ss1, int agrCount) {
+                    return Value.number(5);
+                }
+            });
         }
         else {
             ss.set("player", new ValueMap()
                     .set("name", "MineGame159")
-                    .set("age", (ss1, agrCount) -> Value.number(5))
+                    .set("age", new SFunction() {
+                        @Override
+                        public Value run(Starscript ss1, int agrCount) {
+                            return Value.number(5);
+                        }
+                    })
             );
         }
 

--- a/src/test/java/meteordevelopment/starscript/Main.java
+++ b/src/test/java/meteordevelopment/starscript/Main.java
@@ -3,7 +3,6 @@ package meteordevelopment.starscript;
 import meteordevelopment.starscript.compiler.Compiler;
 import meteordevelopment.starscript.compiler.Parser;
 import meteordevelopment.starscript.utils.Error;
-import meteordevelopment.starscript.utils.SFunction;
 import meteordevelopment.starscript.value.Value;
 import meteordevelopment.starscript.value.ValueMap;
 

--- a/src/test/java/meteordevelopment/starscript/Main.java
+++ b/src/test/java/meteordevelopment/starscript/Main.java
@@ -29,22 +29,12 @@ public class Main {
 
         if (USE_DOT_NOTATION) {
             ss.set("player.name", "MineGame159");
-            ss.set("player.age", new SFunction() {
-                @Override
-                public Value run(Starscript ss1, int agrCount) {
-                    return Value.number(5);
-                }
-            });
+            ss.set("player.age", (ss1, agrCount) -> Value.number(5));
         }
         else {
             ss.set("player", new ValueMap()
                     .set("name", "MineGame159")
-                    .set("age", new SFunction() {
-                        @Override
-                        public Value run(Starscript ss1, int agrCount) {
-                            return Value.number(5);
-                        }
-                    })
+                    .set("age", (ss1, agrCount) -> Value.number(5))
             );
         }
 


### PR DESCRIPTION
Notes:
- Uses RetroLambda to ensure the output is compatible with Java 7, with the ability to auto-convert, try-with-resources, method references, and lambda statements.
  - Note: Compiling with a JDK above 17 will cause RetroLambda to fail, this is an issue in their project, and would need to be forked to locate a suitable fix.
- Adjusted ThreadLocal SB in Section to not use Suppliers, while also technically still retaining it's functionality.
- Switched Supplier with Callable (The main differences is `.call` instead of `.get`, and that Callables have the ability to throw an exception (So that's why there are a bunch of `throws Exception` added to methods.

Use Case:
- Disclosed in Discord DMs, private info relating to un-released product