### PR TITLE
prevent creating variables with keywords as names

### DIFF
--- a/src/main/java/org/meteordev/starscript/Starscript.java
+++ b/src/main/java/org/meteordev/starscript/Starscript.java
@@ -7,10 +7,15 @@ import org.meteordev.starscript.utils.*;
 import org.meteordev.starscript.value.Value;
 import org.meteordev.starscript.value.ValueMap;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /** A VM (virtual machine) that can run compiled starscript code, {@link Script}. */
 public class Starscript {
+    public static final Set<String> KEYWORDS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("null", "true", "false", "and", "or")));
     private final ValueMap globals;
 
     private final Stack<Value> stack = new Stack<>();

--- a/src/main/java/org/meteordev/starscript/value/ValueMap.java
+++ b/src/main/java/org/meteordev/starscript/value/ValueMap.java
@@ -1,6 +1,8 @@
 package org.meteordev.starscript.value;
 
+import org.meteordev.starscript.Starscript;
 import org.meteordev.starscript.utils.SFunction;
+import org.meteordev.starscript.utils.StarscriptError;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -124,6 +126,9 @@ public class ValueMap {
 
     /** Sets the variable supplier for the provided name. */
     public Supplier<Value> setRaw(String name, Supplier<Value> supplier) {
+        if (Starscript.KEYWORDS.contains(name)) {
+            throw new StarscriptError("Variable name cannot be a keyword.");
+        }
         return values.put(name, supplier);
     }
 

--- a/src/test/java/org/meteordev/starscript/Main.java
+++ b/src/test/java/org/meteordev/starscript/Main.java
@@ -3,6 +3,7 @@ package org.meteordev.starscript;
 import org.meteordev.starscript.compiler.Compiler;
 import org.meteordev.starscript.compiler.Parser;
 import org.meteordev.starscript.utils.Error;
+import org.meteordev.starscript.utils.StarscriptError;
 import org.meteordev.starscript.value.Value;
 import org.meteordev.starscript.value.ValueMap;
 
@@ -43,5 +44,10 @@ public class Main {
         ss.remove("player.name");
 
         System.out.println("Output #2: " + ss.run(script));
+
+        try {
+            ss.set("true", Value.null_());
+            throw new AssertionError("Set variable name as keyword.");
+        } catch (StarscriptError ignored) {}
     }
 }


### PR DESCRIPTION
keywords always have priority over variable names in the lexer, therefore we should enforce this constraint by preventing the creation of variables with keywords as names