### PR TITLE
[fix] crash due to minor oversight

### DIFF
--- a/src/main/java/org/meteordev/starscript/compiler/Expr.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Expr.java
@@ -131,6 +131,7 @@ public abstract class Expr {
         }
 
         public Expr getExpr() {
+            if (children.length == 0) return null;
             return children[0];
         }
     }


### PR DESCRIPTION
the crash completely prevents using starscript within meteor in any field which has starscript completions.

only `Block` can end up with no children, so, one line PR.

observation: this crash has only been encountered by two users since meteor upgraded starscript, which suggests that almost no-one modifies starscript expressions