### PR TITLE
Make peeking the Value stack return Value.NULL if it's empty

### DIFF
--- a/src/main/java/org/meteordev/starscript/Starscript.java
+++ b/src/main/java/org/meteordev/starscript/Starscript.java
@@ -125,11 +125,13 @@ public class Starscript {
 
     /** Returns a value from the stack without removing it. */
     public Value peek() {
+        if (stack.size() == 0) return Value.null_();
         return stack.peek();
     }
 
     /** Returns a value from the stack with an offset without removing it. */
     public Value peek(int offset) {
+        if (stack.size() <= offset) return Value.null_();
         return stack.peek(offset);
     }
 

--- a/src/main/java/org/meteordev/starscript/utils/Stack.java
+++ b/src/main/java/org/meteordev/starscript/utils/Stack.java
@@ -34,4 +34,8 @@ public class Stack<T> {
     public T peek(int offset) {
         return items[size - 1 - offset];
     }
+
+    public int size() {
+        return size;
+    }
 }


### PR DESCRIPTION
High-level fix for a bug where trying to call a function on the return of another function (i.e. `{string("a")()}`) caused an unchecked exception if you couldn't call the return value as a function.