### PR TITLE
Add the bitwise operators

### DIFF
--- a/src/main/java/org/meteordev/starscript/Instruction.java
+++ b/src/main/java/org/meteordev/starscript/Instruction.java
@@ -14,6 +14,14 @@ public enum Instruction {
     Modulo,
     Power,
 
+    BitwiseAnd,
+    BitwiseOr,
+    BitwiseXor,
+    BitwiseNot,
+    LeftShift,
+    RightShift,
+    UnsignedRightShift,
+
     AddConstant,
 
     Pop,

--- a/src/main/java/org/meteordev/starscript/Starscript.java
+++ b/src/main/java/org/meteordev/starscript/Starscript.java
@@ -50,19 +50,19 @@ public class Starscript {
                 case Modulo:            { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(a.getNumber() % b.getNumber())); else error("Can only modulo 2 numbers."); break; }
                 case Power:             { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(Math.pow(a.getNumber(), b.getNumber()))); else error("Can only power 2 numbers."); break; }
 
-                case BitwiseAnd:        { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) & ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
-                case BitwiseOr:         { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) | ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
-                case BitwiseXor:        { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) ^ ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
-                case LeftShift:         { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) << ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
-                case RightShift:        { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) >> ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
-                case UnsignedRightShift: { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) >>> ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
+                case BitwiseAnd:        { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number((long) a.getNumber() & (long) b.getNumber())); else error("This operation requires 2 numbers."); break; }
+                case BitwiseOr:         { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number((long) a.getNumber() | (long) b.getNumber())); else error("This operation requires 2 numbers."); break; }
+                case BitwiseXor:        { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number((long) a.getNumber() ^ (long) b.getNumber())); else error("This operation requires 2 numbers."); break; }
+                case LeftShift:         { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number((long) a.getNumber() << (long) b.getNumber())); else error("This operation requires 2 numbers."); break; }
+                case RightShift:        { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number((long) a.getNumber() >> (long) b.getNumber())); else error("This operation requires 2 numbers."); break; }
+                case UnsignedRightShift: { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number((long) a.getNumber() >>> (long) b.getNumber())); else error("This operation requires 2 numbers."); break; }
 
                 case AddConstant:       { Value b = script.constants.get(script.code[ip++] & 0xFF); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(a.getNumber() + b.getNumber())); else if (a.isString()) push(Value.string(a.getString() + b.toString())); else error("Can only add 2 numbers or 1 string and other value."); break; }
 
                 case Pop:               pop(); break;
                 case Not:               push(Value.bool(!pop().isTruthy())); break;
                 case Negate:            { Value a = pop(); if (a.isNumber()) push(Value.number(-a.getNumber())); else error("This operation requires a number."); break; }
-                case BitwiseNot:        { Value a = pop(); if (a.isNumber()) push(Value.number(~((int) a.getNumber()))); else error("This operation requires a number."); break; }
+                case BitwiseNot:        { Value a = pop(); if (a.isNumber()) push(Value.number(~((long) a.getNumber()))); else error("This operation requires a number."); break; }
 
                 case Equals:            push(Value.bool(pop().equals(pop()))); break;
                 case NotEquals:         push(Value.bool(!pop().equals(pop()))); break;

--- a/src/main/java/org/meteordev/starscript/Starscript.java
+++ b/src/main/java/org/meteordev/starscript/Starscript.java
@@ -50,18 +50,26 @@ public class Starscript {
                 case Modulo:            { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(a.getNumber() % b.getNumber())); else error("Can only modulo 2 numbers."); break; }
                 case Power:             { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(Math.pow(a.getNumber(), b.getNumber()))); else error("Can only power 2 numbers."); break; }
 
+                case BitwiseAnd:        { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) & ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
+                case BitwiseOr:         { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) | ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
+                case BitwiseXor:        { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) ^ ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
+                case LeftShift:         { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) << ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
+                case RightShift:        { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) >> ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
+                case UnsignedRightShift: { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(((int) a.getNumber()) >>> ((int) b.getNumber()))); else error("This operation requires 2 numbers."); break; }
+
                 case AddConstant:       { Value b = script.constants.get(script.code[ip++] & 0xFF); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.number(a.getNumber() + b.getNumber())); else if (a.isString()) push(Value.string(a.getString() + b.toString())); else error("Can only add 2 numbers or 1 string and other value."); break; }
 
                 case Pop:               pop(); break;
                 case Not:               push(Value.bool(!pop().isTruthy())); break;
                 case Negate:            { Value a = pop(); if (a.isNumber()) push(Value.number(-a.getNumber())); else error("This operation requires a number."); break; }
+                case BitwiseNot:        { Value a = pop(); if (a.isNumber()) push(Value.number(~((int) a.getNumber()))); else error("This operation requires a number."); break; }
 
                 case Equals:            push(Value.bool(pop().equals(pop()))); break;
                 case NotEquals:         push(Value.bool(!pop().equals(pop()))); break;
-                case Greater:           { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.bool(a.getNumber() > b.getNumber())); else error("This operation requires 2 number."); break; }
-                case GreaterEqual:      { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.bool(a.getNumber() >= b.getNumber())); else error("This operation requires 2 number."); break; }
-                case Less:              { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.bool(a.getNumber() < b.getNumber())); else error("This operation requires 2 number."); break; }
-                case LessEqual:         { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.bool(a.getNumber() <= b.getNumber())); else error("This operation requires 2 number."); break; }
+                case Greater:           { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.bool(a.getNumber() > b.getNumber())); else error("This operation requires 2 numbers."); break; }
+                case GreaterEqual:      { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.bool(a.getNumber() >= b.getNumber())); else error("This operation requires 2 numbers."); break; }
+                case Less:              { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.bool(a.getNumber() < b.getNumber())); else error("This operation requires 2 numbers."); break; }
+                case LessEqual:         { Value b = pop(); Value a = pop(); if (a.isNumber() && b.isNumber()) push(Value.bool(a.getNumber() <= b.getNumber())); else error("This operation requires 2 numbers."); break; }
 
                 case Variable:          { String name = script.constants.get(script.code[ip++] & 0xFF).getString(); Supplier<Value> s = globals.getRaw(name); push(s != null ? s.get() : Value.null_()); break; }
                 case Get:               { String name = script.constants.get(script.code[ip++] & 0xFF).getString(); Value v = pop(); if (!v.isMap()) { push(Value.null_()); break; } Supplier<Value> s = v.getMap().getRaw(name); push(s != null ? s.get() : Value.null_()); break; }

--- a/src/main/java/org/meteordev/starscript/compiler/Compiler.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Compiler.java
@@ -104,7 +104,7 @@ public class Compiler implements Expr.Visitor {
 
             case Ampersand:     script.write(Instruction.BitwiseAnd); break;
             case VBar:          script.write(Instruction.BitwiseOr); break;
-            case VBarUpArrow:   script.write(Instruction.BitwiseXor); break;
+            case DoubleUpArrow:   script.write(Instruction.BitwiseXor); break;
             case DoubleLess:    script.write(Instruction.LeftShift); break;
             case DoubleGreater: script.write(Instruction.RightShift); break;
             case TripleGreater: script.write(Instruction.UnsignedRightShift); break;

--- a/src/main/java/org/meteordev/starscript/compiler/Compiler.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Compiler.java
@@ -88,19 +88,26 @@ public class Compiler implements Expr.Visitor {
         else compile(expr.getRight());
 
         switch (expr.op) {
-            case Plus:         script.write(Instruction.Add); break;
-            case Minus:        script.write(Instruction.Subtract); break;
-            case Star:         script.write(Instruction.Multiply); break;
-            case Slash:        script.write(Instruction.Divide); break;
-            case Percentage:   script.write(Instruction.Modulo); break;
-            case UpArrow:      script.write(Instruction.Power); break;
+            case Plus:          script.write(Instruction.Add); break;
+            case Minus:         script.write(Instruction.Subtract); break;
+            case Star:          script.write(Instruction.Multiply); break;
+            case Slash:         script.write(Instruction.Divide); break;
+            case Percentage:    script.write(Instruction.Modulo); break;
+            case UpArrow:       script.write(Instruction.Power); break;
 
-            case EqualEqual:   script.write(Instruction.Equals); break;
-            case BangEqual:    script.write(Instruction.NotEquals); break;
-            case Greater:      script.write(Instruction.Greater); break;
-            case GreaterEqual: script.write(Instruction.GreaterEqual); break;
-            case Less:         script.write(Instruction.Less); break;
-            case LessEqual:    script.write(Instruction.LessEqual); break;
+            case EqualEqual:    script.write(Instruction.Equals); break;
+            case BangEqual:     script.write(Instruction.NotEquals); break;
+            case Greater:       script.write(Instruction.Greater); break;
+            case GreaterEqual:  script.write(Instruction.GreaterEqual); break;
+            case Less:          script.write(Instruction.Less); break;
+            case LessEqual:     script.write(Instruction.LessEqual); break;
+
+            case Ampersand:     script.write(Instruction.BitwiseAnd); break;
+            case VBar:          script.write(Instruction.BitwiseOr); break;
+            case VBarUpArrow:   script.write(Instruction.BitwiseXor); break;
+            case DoubleLess:    script.write(Instruction.LeftShift); break;
+            case DoubleGreater: script.write(Instruction.RightShift); break;
+            case TripleGreater: script.write(Instruction.UnsignedRightShift); break;
         }
     }
 
@@ -110,6 +117,7 @@ public class Compiler implements Expr.Visitor {
 
         if (expr.op == Token.Bang) script.write(Instruction.Not);
         else if (expr.op == Token.Minus) script.write(Instruction.Negate);
+        else if (expr.op == Token.Tilde) script.write(Instruction.BitwiseNot);
     }
 
     @Override

--- a/src/main/java/org/meteordev/starscript/compiler/Compiler.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Compiler.java
@@ -104,7 +104,7 @@ public class Compiler implements Expr.Visitor {
 
             case Ampersand:     script.write(Instruction.BitwiseAnd); break;
             case VBar:          script.write(Instruction.BitwiseOr); break;
-            case DoubleUpArrow:   script.write(Instruction.BitwiseXor); break;
+            case DoubleUpArrow: script.write(Instruction.BitwiseXor); break;
             case DoubleLess:    script.write(Instruction.LeftShift); break;
             case DoubleGreater: script.write(Instruction.RightShift); break;
             case TripleGreater: script.write(Instruction.UnsignedRightShift); break;

--- a/src/main/java/org/meteordev/starscript/compiler/Lexer.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Lexer.java
@@ -47,8 +47,26 @@ public class Lexer {
 
                     case '=':  if (match('=')) createToken(Token.EqualEqual); else unexpected(); break;
                     case '!':  createToken(match('=') ? Token.BangEqual : Token.Bang); break;
-                    case '>':  createToken(match('=') ? Token.GreaterEqual : Token.Greater); break;
-                    case '<':  createToken(match('=') ? Token.LessEqual : Token.Less); break;
+                    case '>':
+                        if (match('=')) {
+                            createToken(Token.GreaterEqual);
+                            break;
+                        }
+                        if (match('>')) {
+                            createToken(match('>') ? Token.TripleGreater : Token.DoubleGreater);
+                            break;
+                        }
+                        createToken(Token.Greater); break;
+                    case '<':
+                        if (match('=')) {
+                            createToken(Token.LessEqual);
+                            break;
+                        }
+                        if (match('<')) {
+                            createToken(Token.DoubleLess);
+                            break;
+                        }
+                        createToken(Token.Less); break;
 
                     case '+':  createToken(Token.Plus); break;
                     case '-':  createToken(Token.Minus); break;
@@ -70,6 +88,10 @@ public class Lexer {
                         while (isDigit(peek())) advance();
                         createToken(Token.Section, source.substring(start + 1, current));
                         break;
+
+                    case '&': createToken(Token.Ampersand); break;
+                    case '|': createToken(match('^') ? Token.VBarUpArrow : Token.VBar); break;
+                    case '~': createToken(Token.Tilde); break;
 
                     default:   unexpected();
                 }

--- a/src/main/java/org/meteordev/starscript/compiler/Lexer.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Lexer.java
@@ -73,7 +73,7 @@ public class Lexer {
                     case '*':  createToken(Token.Star); break;
                     case '/':  createToken(Token.Slash); break;
                     case '%':  createToken(Token.Percentage); break;
-                    case '^':  createToken(Token.UpArrow); break;
+                    case '^':  createToken(match('^') ? Token.DoubleUpArrow : Token.UpArrow); break;
 
                     case '.':  createToken(Token.Dot); break;
                     case ',':  createToken(Token.Comma); break;
@@ -90,7 +90,7 @@ public class Lexer {
                         break;
 
                     case '&': createToken(Token.Ampersand); break;
-                    case '|': createToken(match('^') ? Token.VBarUpArrow : Token.VBar); break;
+                    case '|': createToken(Token.VBar); break;
                     case '~': createToken(Token.Tilde); break;
 
                     default:   unexpected();

--- a/src/main/java/org/meteordev/starscript/compiler/Parser.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Parser.java
@@ -147,9 +147,22 @@ public class Parser {
 
     private Expr factor() {
         int start = previous.start;
-        Expr expr = unary();
+        Expr expr = bitwise();
 
         while (match(Token.Star, Token.Slash, Token.Percentage, Token.UpArrow)) {
+            Token op = previous.token;
+            Expr right = bitwise();
+            expr = new Expr.Binary(start, previous.end, expr, op, right);
+        }
+
+        return expr;
+    }
+
+    private Expr bitwise() {
+        int start = previous.start;
+        Expr expr = unary();
+
+        while (match(Token.Ampersand, Token.VBar, Token.VBarUpArrow, Token.DoubleLess, Token.DoubleGreater, Token.TripleGreater)) {
             Token op = previous.token;
             Expr right = unary();
             expr = new Expr.Binary(start, previous.end, expr, op, right);
@@ -159,7 +172,7 @@ public class Parser {
     }
 
     private Expr unary() {
-        if (match(Token.Bang, Token.Minus)) {
+        if (match(Token.Bang, Token.Minus, Token.Tilde)) {
             int start = previous.start;
 
             Token op = previous.token;
@@ -352,7 +365,7 @@ public class Parser {
 
         /** Helper method that returns true if there was 1 or more errors. */
         public boolean hasErrors() {
-            return errors.size() > 0;
+            return !errors.isEmpty();
         }
 
         public void accept(Expr.Visitor visitor) {

--- a/src/main/java/org/meteordev/starscript/compiler/Parser.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Parser.java
@@ -162,7 +162,7 @@ public class Parser {
         int start = previous.start;
         Expr expr = unary();
 
-        while (match(Token.Ampersand, Token.VBar, Token.VBarUpArrow, Token.DoubleLess, Token.DoubleGreater, Token.TripleGreater)) {
+        while (match(Token.Ampersand, Token.VBar, Token.DoubleUpArrow, Token.DoubleLess, Token.DoubleGreater, Token.TripleGreater)) {
             Token op = previous.token;
             Expr right = unary();
             expr = new Expr.Binary(start, previous.end, expr, op, right);

--- a/src/main/java/org/meteordev/starscript/compiler/Token.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Token.java
@@ -24,7 +24,8 @@ public enum Token {
     Section,
 
     Ampersand, VBar,
-    Tilde, VBarUpArrow,
+    Tilde,
+    DoubleUpArrow,
     DoubleGreater, TripleGreater,
     DoubleLess,
 

--- a/src/main/java/org/meteordev/starscript/compiler/Token.java
+++ b/src/main/java/org/meteordev/starscript/compiler/Token.java
@@ -23,5 +23,10 @@ public enum Token {
 
     Section,
 
+    Ampersand, VBar,
+    Tilde, VBarUpArrow,
+    DoubleGreater, TripleGreater,
+    DoubleLess,
+
     Error, EOF
 }

--- a/src/main/java/org/meteordev/starscript/utils/SemanticTokenProvider.java
+++ b/src/main/java/org/meteordev/starscript/utils/SemanticTokenProvider.java
@@ -46,7 +46,7 @@ public class SemanticTokenProvider {
                 case Colon:
                 case Ampersand:
                 case VBar:
-                case VBarUpArrow:
+                case DoubleUpArrow:
                 case DoubleLess:
                 case DoubleGreater:
                 case TripleGreater:

--- a/src/main/java/org/meteordev/starscript/utils/SemanticTokenProvider.java
+++ b/src/main/java/org/meteordev/starscript/utils/SemanticTokenProvider.java
@@ -44,6 +44,13 @@ public class SemanticTokenProvider {
                 case Bang:
                 case QuestionMark:
                 case Colon:
+                case Ampersand:
+                case VBar:
+                case VBarUpArrow:
+                case DoubleLess:
+                case DoubleGreater:
+                case TripleGreater:
+                case Tilde:
                     tokens.add(new SemanticToken(SemanticTokenType.Operator, lexer.start, lexer.current));
                     break;
 


### PR DESCRIPTION
Tried to follow Java syntax, but due to the `^` symbol already being used as the exponentiation operator I had to improvise for Xor. Happy to hear other suggestions but I thought this was one of the better compromises. Redefining `^` to be used for Xor and adding something else for exponentiation isn't really an option as it would break existing scripts.

Have to cast the arguments into longs since you can't perform bitwise operations on floating point types. Should we do this and silently floor the arguments, or should we restrict these operators to only be used on whole numbers and error otherwise?

Additions:
`&` - Bitwise And
`|` - Bitwise Or
`|^` - Bitwise Xor
`~` - Bitwise Not
`<<` - Left shift
`>>` - Signed right shift
`>>>` - Unsigned right shift